### PR TITLE
Add integer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 
 [features]
 std=[]
+integer=[]
 
 [profile.release]
 lto = true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+build-integer:
+	@cargo +nightly build --no-default-features --features=integer
+
+build:
+	@cargo +nightly build --no-default-features
+
+run-tests:
+	@cargo +nightly test --features=integer
+
+clippy:
+	@cargo +nightly clippy --features=integer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+build-integer:
+	@cargo +nightly build --no-default-features --features=integer
+	
+build:
+	@cargo +nightly build --no-default-features
+	
+run-tests:
+	@cargo +nightly test --no-default-features --features=integer
+
+clippy:
+	@cargo +nightly clippy --no-default-features --features=integer

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@
 * We allow `,` after the last item/member of Array/Object.
 * We treat unescaped line breaks as normal char, and ignore escaped line breaks.
 * We do not support surrogate unicode char.
-* We use `f64` for all numbers, but you can use others. Remind: `f64` means `i52`.
+* We use `f64` for all numbers. Also supported `u64`, `i64`. JSON standard 
+  not supported `u128` and `i128`. Any other number you can simply cast.
+  To enable integers use feature `integer` (see [tests/mod.rs](tests/mod.rs)). 
+  Remind: `f64` means `i52`.
 * We take `&[char]`, not `&[u8]`, and not `&str`.
 * No `stringify` or `encode`, because they should not be a part of the traits.
 * Instead of returning `None`, we simply ignore chars after the data.
 * The position where data ends is returned through `index`. You can compare it with `len() - 1`.
 * This value is also useful when `Option::None` returned, by indicating where the syntax error occurs.
 * `parse` may return all possible values, not only `Array` and `Object`.
+
+For more examples and additional parsers you can see [tests/mod.rs](tests/mod.rs).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,17 +64,17 @@ pub fn parse<T: Value<A, O, N>, A: Array<T, O, N>, O: Object<T, A, N>, N: Null<T
         return Option::None;
     }
     if src[*index] == '{' {
-        parse_object::<T, A, O, N>(src, index).map(|v| T::from(v))
+        parse_object::<T, A, O, N>(src, index).map(T::from)
     } else if src[*index] == '[' {
-        parse_array::<T, A, O, N>(src, index).map(|v| T::from(v))
+        parse_array::<T, A, O, N>(src, index).map(T::from)
     } else if src[*index] == 't' {
-        parse_true(src, index).map(|v| T::from(v))
+        parse_true(src, index).map(T::from)
     } else if src[*index] == 'f' {
-        parse_false(src, index).map(|v| T::from(v))
+        parse_false(src, index).map(T::from)
     } else if src[*index] == '"' {
-        parse_string(src, index).map(|v| T::from(v))
+        parse_string(src, index).map(T::from)
     } else if src[*index] == 'n' {
-        parse_null::<T, A, O, N>(src, index).map(|v| T::from(v))
+        parse_null::<T, A, O, N>(src, index).map(T::from)
     } else if src[*index] == '-' || src[*index].is_ascii_digit() {
         parse_number(src, index).map(|v| match v {
             #[cfg(feature = "integer")]
@@ -113,9 +113,6 @@ fn parse_object<T: Value<A, O, N>, A: Array<T, O, N>, O: Object<T, A, N>, N: Nul
             return Some(v);
         }
         let k = parse_string(src, index);
-        if k.is_none() {
-            return Option::None;
-        }
         while src.len() > *index && is_space(src[*index]) {
             *index += 1;
         }
@@ -133,10 +130,7 @@ fn parse_object<T: Value<A, O, N>, A: Array<T, O, N>, O: Object<T, A, N>, N: Nul
             return Option::None;
         }
         let c = parse::<T, A, O, N>(src, index);
-        if c.is_none() {
-            return Option::None;
-        }
-        v.insert(k.unwrap(), c.unwrap());
+        v.insert(k?, c?);
         while src.len() > *index && is_space(src[*index]) {
             *index += 1;
         }
@@ -176,10 +170,7 @@ fn parse_array<T: Value<A, O, N>, A: Array<T, O, N>, O: Object<T, A, N>, N: Null
             return Some(v);
         }
         let i = parse::<T, A, O, N>(src, index);
-        if i.is_none() {
-            return Option::None;
-        }
-        v.push(i.unwrap());
+        v.push(i?);
         while src.len() > *index && is_space(src[*index]) {
             *index += 1;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,15 @@ where
     fn new() -> Self;
 }
 
+#[cfg(not(feature = "integer"))]
 pub trait Value<A: Array<Self, O, N>, O: Object<Self, A, N>, N: Null<Self, A, O>>:
     From<String> + From<f64> + From<bool> + From<A> + From<O> + From<N>
+{
+}
+
+#[cfg(feature = "integer")]
+pub trait Value<A: Array<Self, O, N>, O: Object<Self, A, N>, N: Null<Self, A, O>>:
+    From<String> + From<f64> + From<i64> + From<u64> + From<bool> + From<A> + From<O> + From<N>
 {
 }
 
@@ -63,7 +70,7 @@ pub fn parse<T: Value<A, O, N>, A: Array<T, O, N>, O: Object<T, A, N>, N: Null<T
     } else if src[*index] == 'n' {
         parse_null::<T, A, O, N>(src, index).map(|v| T::from(v))
     } else if src[*index] == '-' || src[*index].is_ascii_digit() {
-        parse_number(src, index).map(|v| T::from(v))
+        parse_number::<T>(src, index).map(|v| T::from(v))
     } else {
         Option::None
     }
@@ -301,7 +308,10 @@ fn parse_number_decimal(src: &[char], index: &mut usize) -> f64 {
     }
 }
 
-fn parse_number(src: &[char], index: &mut usize) -> Option<f64> {
+fn parse_number<T: From<f64> + From<i64> + From<u64>>(
+    src: &[char],
+    index: &mut usize,
+) -> Option<f64> {
     let mut v: f64 = 0 as f64;
     let mut sign = 1;
     if src.len() <= *index {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,20 +1,22 @@
 extern crate rjson;
-use std::vec::Vec;
+use rjson::parse;
+use rjson::Array;
+use rjson::Null;
+use rjson::Object;
+use rjson::Value;
 use std::collections::BTreeMap;
 use std::convert::From;
-use rjson::Value;
-use rjson::Array;
-use rjson::Object;
-use rjson::Null;
-use rjson::parse;
+use std::vec::Vec;
 
 enum JsonValue {
     Null,
     Number(f64),
+    U64(u64),
+    I64(i64),
     Bool(bool),
     String(String),
     Array(Vec<JsonValue>),
-    Object(BTreeMap<String, JsonValue>)
+    Object(BTreeMap<String, JsonValue>),
 }
 
 struct JsonArray(Vec<JsonValue>);
@@ -50,13 +52,23 @@ impl From<f64> for JsonValue {
         JsonValue::Number(v)
     }
 }
+impl From<u64> for JsonValue {
+    fn from(v: u64) -> Self {
+        JsonValue::U64(v)
+    }
+}
+impl From<i64> for JsonValue {
+    fn from(v: i64) -> Self {
+        JsonValue::I64(v)
+    }
+}
 impl From<bool> for JsonValue {
     fn from(v: bool) -> Self {
         JsonValue::Bool(v)
     }
 }
 impl From<String> for JsonValue {
-    fn from(v: String) -> Self{
+    fn from(v: String) -> Self {
         JsonValue::String(v)
     }
 }
@@ -77,15 +89,17 @@ impl std::fmt::Debug for JsonValue {
             JsonValue::Null => f.write_str("null"),
             JsonValue::String(ref v) => f.write_fmt(format_args!("\"{}\"", v)),
             JsonValue::Number(ref v) => f.write_fmt(format_args!("{}", v)),
+            JsonValue::U64(ref v) => f.write_fmt(format_args!("{}", v)),
+            JsonValue::I64(ref v) => f.write_fmt(format_args!("{}", v)),
             JsonValue::Bool(ref v) => f.write_fmt(format_args!("{}", v)),
             JsonValue::Array(ref v) => f.write_fmt(format_args!("{:?}", v)),
-            JsonValue::Object(ref v) => f.write_fmt(format_args!("{:#?}", v))
+            JsonValue::Object(ref v) => f.write_fmt(format_args!("{:#?}", v)),
         }
     }
 }
 
 impl std::fmt::Display for JsonValue {
-    fn fmt(&self, f:&mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.write_fmt(format_args!("{:?}", *self))
     }
 }
@@ -95,11 +109,11 @@ fn test() {
     let data = include_str!("./test.json");
     let data_array: Vec<char> = data.chars().collect();
     let mut index = 0;
-    let interpreted = parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data_array, &mut index);
+    let interpreted =
+        parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data_array, &mut index);
     assert_eq!(index, data_array.len() - 1);
     assert!(interpreted.is_some());
     // That means the parser has reached and the data is there.
     // We should test whether the data is good or not, but it is...boring.
     println!("{}", interpreted.unwrap()); // run with --nocapture to check result.
 }
-

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -8,7 +8,8 @@ use std::collections::BTreeMap;
 use std::convert::From;
 use std::vec::Vec;
 
-enum JsonValue {
+#[derive(PartialEq)]
+pub enum JsonValue {
     Null,
     Number(f64),
     U64(u64),
@@ -104,6 +105,44 @@ impl std::fmt::Display for JsonValue {
     }
 }
 
+pub fn parse_json(data: &str) -> Option<JsonValue> {
+    let data_array: Vec<char> = data.chars().collect();
+    let mut index = 0;
+    rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data_array, &mut index)
+}
+
+impl JsonValue {
+    pub fn f64(&self, key: &str) -> Option<f64> {
+        match self {
+            JsonValue::Object(o) => match o.get(key)? {
+                JsonValue::Number(n) => Some(*n),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn u64(&self, key: &str) -> Option<u64> {
+        match self {
+            JsonValue::Object(o) => match o.get(key)? {
+                JsonValue::U64(n) => Some(*n),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn i64(&self, key: &str) -> Option<i64> {
+        match self {
+            JsonValue::Object(o) => match o.get(key)? {
+                JsonValue::I64(n) => Some(*n),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
 #[test]
 fn test() {
     let data = include_str!("./test.json");
@@ -116,4 +155,101 @@ fn test() {
     // That means the parser has reached and the data is there.
     // We should test whether the data is good or not, but it is...boring.
     println!("{}", interpreted.unwrap()); // run with --nocapture to check result.
+}
+
+#[cfg(feature = "integer")]
+#[test]
+fn test_f64() {
+    let json_val = parse_json(r#"{"number": 1.23}"#).unwrap();
+    let val = json_val.f64("number").unwrap();
+    assert_eq!(val, 1.23);
+
+    let json_val = parse_json(r#"{"number": -1.23}"#).unwrap();
+    let val = json_val.f64("number").unwrap();
+    assert_eq!(val, -1.23);
+
+    let json_val = parse_json(r#"{"number": 123}"#).unwrap();
+    let val = json_val.f64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": -123}"#).unwrap();
+    let val = json_val.f64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": "123"}"#).unwrap();
+    let val = json_val.f64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": {}}"#).unwrap();
+    let val = json_val.f64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": []}"#).unwrap();
+    let val = json_val.f64("number");
+    assert!(val.is_none());
+}
+
+#[cfg(feature = "integer")]
+#[test]
+fn test_i64() {
+    let json_val = parse_json(r#"{"number": 123}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": -123}"#).unwrap();
+    let val = json_val.i64("number").unwrap();
+    assert_eq!(val, -123);
+
+    let json_val = parse_json(r#"{"number": 1.23}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": -1.23}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": "123"}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": {}}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": []}"#).unwrap();
+    let val = json_val.i64("number");
+    assert!(val.is_none());
+}
+
+#[cfg(feature = "integer")]
+#[test]
+fn test_u64() {
+    let json_val = parse_json(r#"{"number": 123}"#).unwrap();
+    let val = json_val.u64("number").unwrap();
+    assert_eq!(val, 123);
+
+    let json_val = parse_json(r#"{"number": -123}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": 1.23}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": -1.23}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
+
+
+    let json_val = parse_json(r#"{"number": "123"}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": {}}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
+
+    let json_val = parse_json(r#"{"number": []}"#).unwrap();
+    let val = json_val.u64("number");
+    assert!(val.is_none());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -240,7 +240,6 @@ fn test_u64() {
     let val = json_val.u64("number");
     assert!(val.is_none());
 
-
     let json_val = parse_json(r#"{"number": "123"}"#).unwrap();
     let val = json_val.u64("number");
     assert!(val.is_none());

--- a/tests/test.json
+++ b/tests/test.json
@@ -21,6 +21,7 @@ null, false
 
 "true"
 :
-"false"
-
+"false",
+  "integer1": 10,
+  "integer2": -10
 }


### PR DESCRIPTION
* added Integer target types: i64, u64
* added additional tests

So supported Number types: f64, i64, u64

Motivation: f64 only number parsing for i64, u64 types has pitfalls for production use.

Integer types enabling via `integer` cargo feature.

Fully compatible with the previous release. So users shouldn't change anything.